### PR TITLE
Bug/KRV-1411: tenant with same name is not working in multiarray environment

### DIFF
--- a/api/apiconstants.go
+++ b/api/apiconstants.go
@@ -18,6 +18,8 @@ const (
 
 	UnityApiInstanceTypeResources = unityApiTypes + "/%s" + "/instances"
 
+	UnityApiGetTenantUri = UnityApiInstanceTypeResources + "?&compact=true&fields=%s"
+
 	UnityApiInstanceTypeResourcesWithFields = UnityApiInstanceTypeResources + "?fields=%s"
 
 	UnityApiInstancesUri = unityRootApi + "/instances"
@@ -98,4 +100,5 @@ const (
 	HostInitiatorAction     = "hostInitiator"
 	HostIPPortAction        = "hostIPPort"
 	NasServerAction         = "nasServer"
+	TenantAction            = "tenant"
 )

--- a/field_constants.go
+++ b/field_constants.go
@@ -10,6 +10,9 @@ const (
 	//To Display Storage Resource fields
 	StorageResourceDisplayFields = "id,name,filesystem"
 
+	//To Display Tenants fields
+	TenantDisplayFields = "id,name"
+
 	//To Display the NFS Share fields
 	NFSShareDisplayfields = "id,name,filesystem,readOnlyHosts,readWriteHosts,readOnlyRootAccessHosts,rootAccessHosts,exportPaths"
 

--- a/host.go
+++ b/host.go
@@ -279,7 +279,7 @@ func (h *host) FindFcPortById(ctx context.Context, fcPortId string) (*types.FcPo
 	return fcPortResp, nil
 }
 
-func (h *host) FindTenants(ctx context.Context) (*types.Host, error) {
+func (h *host) FindTenants(ctx context.Context) (*types.TenantInfo, error) {
 	tenantsResp := &types.TenantInfo{}
 	err := h.client.executeWithRetryAuthenticate(ctx, http.MethodGet, fmt.Sprintf(api.UnityApiGetTenantUri,api.TenantAction,TenantDisplayFields), nil, tenantsResp)
 	if err != nil {

--- a/host.go
+++ b/host.go
@@ -278,3 +278,12 @@ func (h *host) FindFcPortById(ctx context.Context, fcPortId string) (*types.FcPo
 	}
 	return fcPortResp, nil
 }
+
+func (h *host) FindTenantIdByName(ctx context.Context) (*types.Host, error) {
+	tenantsResp := &types.Tenants{}
+	err := h.client.executeWithRetryAuthenticate(ctx, http.MethodGet, fmt.Sprintf(api.UnityApiGetTenantUri,api.TenantAction,TenantDisplayFields), nil, tenantsResp)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Unable to find tenants : %v", err))
+	}
+	return  tenantsResp, nil
+}

--- a/host.go
+++ b/host.go
@@ -279,7 +279,7 @@ func (h *host) FindFcPortById(ctx context.Context, fcPortId string) (*types.FcPo
 	return fcPortResp, nil
 }
 
-func (h *host) FindTenantIdByName(ctx context.Context) (*types.Host, error) {
+func (h *host) FindTenants(ctx context.Context) (*types.Host, error) {
 	tenantsResp := &types.Tenants{}
 	err := h.client.executeWithRetryAuthenticate(ctx, http.MethodGet, fmt.Sprintf(api.UnityApiGetTenantUri,api.TenantAction,TenantDisplayFields), nil, tenantsResp)
 	if err != nil {

--- a/host.go
+++ b/host.go
@@ -280,7 +280,7 @@ func (h *host) FindFcPortById(ctx context.Context, fcPortId string) (*types.FcPo
 }
 
 func (h *host) FindTenants(ctx context.Context) (*types.Host, error) {
-	tenantsResp := &types.Tenants{}
+	tenantsResp := &types.TenantInfo{}
 	err := h.client.executeWithRetryAuthenticate(ctx, http.MethodGet, fmt.Sprintf(api.UnityApiGetTenantUri,api.TenantAction,TenantDisplayFields), nil, tenantsResp)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Unable to find tenants : %v", err))

--- a/types/response.go
+++ b/types/response.go
@@ -89,6 +89,19 @@ type Link struct {
 	Href string `json:"href"`
 }
 
+type TenantInfo struct {
+	Entries []TenantEntry `json:"entries"`
+}
+
+type TenantEntry struct {
+	Content TenantContent `json:"content"`
+}
+
+type TenantContent struct {
+	Id string `json:"id"`
+	Name string `json:"name"`
+}
+
 //BasicSystemInfo Struct to capture the BasicSystemInfo response
 type BasicSystemInfo struct {
 	Base    string    `json:"@base"`


### PR DESCRIPTION
# Description
Bug fix for tenant with same name is not working in multiarray environment
# GitHub Issues
KRV-1411: tenant with same name is not working in multiarray environment


# Checklist:

-  I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
-  I have verified that new and existing unit tests pass locally with my changes
-   I have not allowed coverage numbers to degenerate
-  I have maintained at least 90% code coverage
-  I have commented my code, particularly in hard-to-understand areas
-  I have made corresponding changes to the documentation
-  I have added tests that prove my fix is effective or that my feature works
-  Backward compatibility is not broken

# How Has This Been Tested?
myvalues :
![3](https://user-images.githubusercontent.com/92289639/141921824-17820a84-a929-4ebc-84dd-7683a408544e.PNG)

tenant logs :
![2](https://user-images.githubusercontent.com/92289639/141921851-9d4bf9a1-3358-4ba6-95c9-9966595137be.PNG)

tenant added in unity array :
![1](https://user-images.githubusercontent.com/92289639/141921840-2924f6f2-ef99-4fc4-bb0d-d100640f2f92.PNG)



