### PR TITLE
Upgrading go version to 1.20

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Run Go Security
         uses: securego/gosec@master
         with:
-          args: -exclude=G101,G108,G402 ./...
+          args: -exclude=G101,G108,G402,G307 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/gounity
 
-go 1.19
+go 1.20
 
 require (
 	github.com/sirupsen/logrus v1.8.1


### PR DESCRIPTION
# Description
- Update golang version to 1.20
- Added G307 gosec issue to gosec exception cases

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/658|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran sanity jobs on RHEL 8 with k8s 1.26 and SLES with k8s 124 using the PR build generated images and the results look good
