### PR TITLE
Handling 401 response code during stig mode

### DIFF
--- a/unityclient.go
+++ b/unityclient.go
@@ -131,10 +131,8 @@ func (c *Client) executeWithRetryAuthenticate(ctx context.Context, method, uri s
 			log.Debug("need to re-authenticate")
 			// Authenticate then try again
 			configConnect := c.configConnect
-			// insecure, _ := strconv.ParseBool(os.Getenv("GOUNITY_INSECURE"))
-			log.Info("insecure flag when response code is 401: %t", configConnect.Insecure)
 			c, err = NewClientWithArgs(ctx, configConnect.Endpoint, configConnect.Insecure)
-			log.Info("config connect info during reauth when response code: %v", configConnect)
+			log.Info("insecure flag when response code is 401: %t", configConnect.Insecure)
 
 			if err != nil {
 				log.Debug("Failed creating a new goUnity client during reauth when response code is 401 ")

--- a/unityclient.go
+++ b/unityclient.go
@@ -45,17 +45,18 @@ var (
 	showHTTP, _ = strconv.ParseBool(os.Getenv("GOUNITY_SHOWHTTP"))
 )
 
-//Client Struct holds the configuration & REST Client.
+// Client Struct holds the configuration & REST Client.
 type Client struct {
 	configConnect *ConfigConnect
 	api           api.Client
 }
 
-//ConfigConnect Struct holds the endpoint & credential info.
+// ConfigConnect Struct holds the endpoint & credential info.
 type ConfigConnect struct {
 	Endpoint string
 	Username string
 	Password string
+	Insecure bool
 }
 
 // Authenticate make a REST API call [/loginSessionInfo] to Unity to get authenticate the given credentials.
@@ -129,7 +130,18 @@ func (c *Client) executeWithRetryAuthenticate(ctx context.Context, method, uri s
 		if e.ErrorContent.HTTPStatusCode == 401 {
 			log.Debug("need to re-authenticate")
 			// Authenticate then try again
-			if err := c.Authenticate(ctx, c.configConnect); err != nil {
+			configConnect := c.configConnect
+			// insecure, _ := strconv.ParseBool(os.Getenv("GOUNITY_INSECURE"))
+			log.Info("insecure flag when response code is 401: %t", configConnect.Insecure)
+			c, err = NewClientWithArgs(ctx, configConnect.Endpoint, configConnect.Insecure)
+			log.Info("config connect info during reauth when response code: %v", configConnect)
+
+			if err != nil {
+				log.Debug("Failed creating a new goUnity client during reauth when response code is 401 ")
+				return err
+			}
+
+			if err := c.Authenticate(ctx, configConnect); err != nil {
 				return fmt.Errorf("authentication failure due to: %v", err)
 			}
 			log.Debug("Authentication success")
@@ -143,12 +155,12 @@ func (c *Client) executeWithRetryAuthenticate(ctx context.Context, method, uri s
 	return err
 }
 
-//SetToken function sets token
+// SetToken function sets token
 func (c *Client) SetToken(token string) {
 	c.api.SetToken(token)
 }
 
-//GetToken function gets token
+// GetToken function gets token
 func (c *Client) GetToken() string {
 	return c.api.GetToken()
 }

--- a/unityclient.go
+++ b/unityclient.go
@@ -132,7 +132,6 @@ func (c *Client) executeWithRetryAuthenticate(ctx context.Context, method, uri s
 			// Authenticate then try again
 			configConnect := c.configConnect
 			c, err = NewClientWithArgs(ctx, configConnect.Endpoint, configConnect.Insecure)
-			log.Info("insecure flag when response code is 401: %t", configConnect.Insecure)
 
 			if err != nil {
 				log.Debug("Failed creating a new goUnity client during reauth when response code is 401 ")


### PR DESCRIPTION
# Description
Added logic to recreate a session when Unity XT driver hits 401 error code when operating in STIG mode

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/891 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- Ran Sanity jobs to ensure there is no impact