### PR TITLE
Update Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,14 +7,21 @@
 # be requested for review when someone opens a pull request.
 # Order is alphabetical for easier maintenance.
 #
+# Adam Ginna (adamginna-dell)
+# Bartosz Ciesielczyk (cbartoszDell)
+# Bogdan Novikov (bogdanNovikovDell)
 # Deepak Ghivari (Deepak-Ghivari)
 # Francis Nijay (francis-nijay)
 # Karthik K (karthikk92)
 # Keerthi Bandapati (bandak2)
+# Leonard Ulman (Leonard-Dell)
+# Marcin Trajfacki (mtrajfacki-dell)
+# Marek Suski (mareksuski-dell)
+# Mateusz Urbanek (shanduur-dell)
+# Małgorzata Dutka (mdutka-dell)
 # Rajendra Indukuri (rajendraindukuri)
 # Rensy Thomas (rensyct)
 # Spandita Panigrahi (panigs7)
 
 # for all files:
-* @Deepak-Ghivari @francis-nijay @karthikk92 @bandak2 @rajendraindukuri @rensyct @panigs7
-
+* @Deepak-Ghivari @francis-nijay @karthikk92 @bandak2 @rajendraindukuri @rensyct @panigs7 @adamginna-dell @cbartoszDell @bogdanNovikovDell @Leonard-Dell @mtrajfacki-dell @mareksuski-dell @shanduur-dell @mdutka-dell


### PR DESCRIPTION
<!--
 Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
This PR updates the Codeowners list.
