### PR TITLE
Adjust Log Level Based on Debug Flags

### DIFF
--- a/unityclient.go
+++ b/unityclient.go
@@ -41,9 +41,7 @@ var (
 	accHeader string
 	conHeader string
 
-	errNoLink   = errors.New("error: problem finding link")
-	debug, _    = strconv.ParseBool(os.Getenv("GOUNITY_DEBUG"))
-	showHTTP, _ = strconv.ParseBool(os.Getenv("GOUNITY_SHOWHTTP"))
+	errNoLink = errors.New("error: problem finding link")
 )
 
 // Client Struct holds the configuration & REST Client.
@@ -202,15 +200,15 @@ func NewClient(ctx context.Context) (client *Client, err error) {
 // NewClientWithArgs initialize the new REST Client with the given arguments.
 func NewClientWithArgs(ctx context.Context, endpoint string, insecure bool) (client *Client, err error) {
 	log := util.GetRunIDLogger(ctx)
-	if showHTTP {
-		debug = true
+	if util.ShowHTTP {
+		util.Debug = true
 	}
 
 	fields := map[string]interface{}{
 		"endpoint": endpoint,
 		"insecure": insecure,
-		"debug":    debug,
-		"showHTTP": showHTTP,
+		"debug":    util.Debug,
+		"showHTTP": util.ShowHTTP,
 	}
 
 	log.WithFields(fields).Debug("unity client init")
@@ -222,10 +220,10 @@ func NewClientWithArgs(ctx context.Context, endpoint string, insecure bool) (cli
 
 	opts := api.ClientOptions{
 		Insecure: insecure,
-		ShowHTTP: showHTTP,
+		ShowHTTP: util.ShowHTTP,
 	}
 
-	ac, err := api.New(ctx, endpoint, opts, debug)
+	ac, err := api.New(ctx, endpoint, opts, util.Debug)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create HTTP client %v", err)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -37,6 +37,11 @@ var (
 	ErrorInvalidCharacters = errors.New("name contains invalid characters or name doesn't start with alphabetic. Allowed characters are 'a-zA-Z0-9_-'")
 )
 
+var (
+	Debug, _    = strconv.ParseBool(os.Getenv("GOUNITY_DEBUG"))
+	ShowHTTP, _ = strconv.ParseBool(os.Getenv("GOUNITY_SHOWHTTP"))
+)
+
 type contextKey string
 
 const UnityLog contextKey = "unitylog"
@@ -75,6 +80,11 @@ func GetLogger() *logrus.Logger {
 
 		// Gounity users can make use of this environment variable to initialize log level. Default level will be Info
 		logLevel := os.Getenv("X_CSI_LOG_LEVEL")
+
+		// in addition, if Debug flag or ShowHTTP flag is set, then set log level to debug
+		if Debug || ShowHTTP {
+			logLevel = "debug"
+		}
 
 		ChangeLogLevel(logLevel)
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -26,8 +26,8 @@ import (
 const MaxResourceNameLength = 63
 
 func TestUtils(t *testing.T) {
+	getLoggerTest(t)
 	getRunIDLoggerTest(t)
-	getLoggetTest(t)
 	validateResourceNameTest(t)
 	validateDurationTest(t)
 	getSecuredCipherSuitesTest(t)
@@ -72,11 +72,13 @@ func getRunIDLoggerTest(t *testing.T) {
 	fmt.Println("Get RunId Logger Test Successful")
 }
 
-func getLoggetTest(_ *testing.T) {
+func getLoggerTest(_ *testing.T) {
 	fmt.Println("Begin - Get Logger Test")
-
+	// debug flag needs to be true to hit a test condition, reset it after
+	formerDebug := Debug
+	Debug = true
 	_ = GetLogger()
-
+	Debug = formerDebug
 	fmt.Println("Get Logger Test Successful")
 }
 


### PR DESCRIPTION
# Description
Debug flag now appropriately sets log level. Show HTTP flag also sets log level to 'debug' as needed. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1762 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
I have manually built an image of csi-unity using the updated gounity and verified that the environment variables being set in the driver container change the logs that are printed, displaying debug logs when GOUNITY_DEBUG or GOUNITY_SHOWHTTP are set to true and displaying appropriate loglines. 