### PR TITLE
n-x release fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,40 @@ on:  # yamllint disable-line rule:truthy
           - major
           - minor
           - patch
+          - n-1/n-2 patch (Provide input in the below box)
+      version:
+        description: "Patch version to release. example: 2.1.x (Use this only if n-1/n-2 patch is selected)"
+        required: false
+        type: string
   repository_dispatch:
     types: [release-go-libs]
 jobs:
+  process-inputs:
+    name: Process Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      processedVersion: ${{ steps.set-version.outputs.versionEnv }}
+    steps:
+      - name: Process input
+        id: set-version
+        shell: bash
+        run: |
+          if [[ "${{ github.event.inputs.version }}" != "" && "${{ github.event.inputs.option }}" == "n-1/n-2 patch (Provide input in the below box)" ]]; then
+            # if both version and option are provided, then version takes precedence i.e. patch release for n-1/n-2
+            echo "versionEnv=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [[ "${{ github.event.inputs.option }}" != "n-1/n-2 patch (Provide input in the below box)" ]]; then
+            # if only option is provided, then option takes precedence i.e. minor, major or patch release
+            echo "versionEnv=${{ github.event.inputs.option }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # if neither option nor version is provided, then minor release is taken by default (Auto-release)
+          echo "versionEnv=minor" >> $GITHUB_OUTPUT
   csm-release:
+    needs: [process-inputs]
     uses: dell/common-github-actions/.github/workflows/csm-release-libs.yaml@main
     name: Release Go Client Libraries
     with:
-      version: "${{ github.event.inputs.option || 'minor' }}"
+      version: ${{ needs.process-inputs.outputs.processedVersion }}
     secrets: inherit


### PR DESCRIPTION
<!--
 Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
      http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
n-x release fix
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1490 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested in fork for n-1 patch (Libraries) : https://github.com/harishp8889/test-gofsutil-automation/actions/runs/14358132666/job/40252397613
Tested in fork for normal version release (Libraries): https://github.com/harishp8889/test-gofsutil-automation/actions/runs/14358438427/job/40253395851